### PR TITLE
change shebang line so pgtune is started with python2

### DIFF
--- a/pgtune
+++ b/pgtune
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 pgtune
 


### PR DESCRIPTION
pgtune uses python2 syntax (e.g. print not called as function) so it should be started with python2. 
