### PR TITLE
wal_buffers for 9.1

### DIFF
--- a/pg_settings-9.1-64
+++ b/pg_settings-9.1-64
@@ -195,6 +195,7 @@ vacuum_defer_cleanup_age	0		Replication / Master Server	Number of transactions b
 vacuum_freeze_min_age	50000000		Client Connection Defaults / Statement Behavior	Minimum age at which VACUUM should freeze a table row.	\N	user	integer	0	1000000000	\N	50000000
 vacuum_freeze_table_age	150000000		Client Connection Defaults / Statement Behavior	Age at which VACUUM should scan whole table to freeze tuples.	\N	user	integer	0	2000000000	\N	150000000
 wal_block_size	8192		Preset Options	Shows the block size in the write ahead log.	\N	internal	integer	8192	8192	\N	8192
+wal_buffers	-1	8kB	Write-Ahead Log / Settings	Sets the number of disk-page buffers in shared memory for WAL.	\N	postmaster	integer	4	2147483647	\N	8
 wal_keep_segments	0		Replication / Master Server	Sets the number of WAL files held for standby servers.	\N	sighup	integer	0	2147483647	\N	0
 wal_level	minimal	\N	Write-Ahead Log / Settings	Set the level of information written to the WAL.	\N	postmaster	enum	\N	\N	{minimal,archive,hot_standby}	minimal
 wal_receiver_status_interval	10	s	Replication / Standby Servers	Sets the maximum interval between WAL receiver status reports to the primary.	\N	sighup	integer	0	2147483	\N	10

--- a/pgtune
+++ b/pgtune
@@ -556,17 +556,18 @@ def wizard_tune(config, options, settings):
     s['checkpoint_completion_target'] = {'web':0.7, 'oltp':0.9, 'dw':0.9,
                                          'mixed':0.9, 'desktop':0.5}[db_type]
   
-    # Follow auto-tuning guideline for wal_buffers added in 9.1, where it's
-    # set to 3% of shared_buffers up to a maximum of 16MB.
-    # TODO Eliminate setting this at all on 9.1 and later
-    s['wal_buffers'] = 3 * s['shared_buffers'] / 100
-    if s['wal_buffers'] > 16*MB / KB:
-        s['wal_buffers'] = 16*MB / KB
-    # It's nice if wal_buffers is an even 16MB if it's near that number.  Since
-    # that is a common case on Windows, where shared_buffers is clipped to 512MB,
-    # round upwards in that situation
-    if s['wal_buffers'] > 14*MB / KB and s['wal_buffers'] < 16*MB / KB:
-        s['wal_buffers'] = 16*MB / KB
+    # For versions < 9.1, follow auto-tuning guideline for wal_buffers added
+    # in 9.1, where it's set to 3% of shared_buffers up to a maximum of 16MB.
+    # Starting with 9.1, the default value of -1 should be fine.
+    if float(options.db_version) < 9.1:
+        s['wal_buffers'] = 3 * s['shared_buffers'] / 100
+        if s['wal_buffers'] > 16*MB / KB:
+            s['wal_buffers'] = 16*MB / KB
+        # It's nice if wal_buffers is an even 16MB if it's near that number.  Since
+        # that is a common case on Windows, where shared_buffers is clipped to 512MB,
+        # round upwards in that situation
+        if s['wal_buffers'] > 14*MB / KB and s['wal_buffers'] < 16*MB / KB:
+            s['wal_buffers'] = 16*MB / KB
 
     # TODO Eliminate setting this needlessly when on a version that
     # defaults to 100  


### PR DESCRIPTION
If you try to parse a 9.1 config file, you will blow up like this:

```